### PR TITLE
Fix intake history queries

### DIFF
--- a/src/components/CalendarLog.tsx
+++ b/src/components/CalendarLog.tsx
@@ -27,11 +27,11 @@ export const CalendarLog = () => {
     queryKey: ['intakes-month', month.toISOString(), user],
     queryFn: async () => {
       const { data, error } = await supabase
-        .from('intake_logs')
-        .select('id, taken_at, quantity, supplements (name), user_name')
+        .from('intakes')
+        .select('id, taken_at, dosage, supplements(name), user_id')
         .gte('taken_at', startOfMonth(month).toISOString())
         .lte('taken_at', endOfMonth(month).toISOString())
-        .eq('user_name', user);
+        .eq('user_id', user);
       if (error) throw error;
       return data || [];
     },
@@ -116,7 +116,7 @@ export const CalendarLog = () => {
           <TableHeader>
             <TableRow className="hover:bg-transparent">
               <TableHead className="text-muted-foreground">Supplement</TableHead>
-              <TableHead className="text-muted-foreground text-center">Quantity</TableHead>
+              <TableHead className="text-muted-foreground text-center">Dosage</TableHead>
               <TableHead className="text-muted-foreground text-right">Time</TableHead>
             </TableRow>
           </TableHeader>
@@ -131,7 +131,7 @@ export const CalendarLog = () => {
               intakes.map((intake) => (
                 <TableRow key={intake.id} className="hover:bg-accent/50 border-border">
                   <TableCell className="font-medium">{intake.supplements?.name || 'Unknown'}</TableCell>
-                  <TableCell className="text-center">{intake.quantity}</TableCell>
+                  <TableCell className="text-center">{intake.dosage}</TableCell>
                   <TableCell className="text-right">
                     {format(new Date(intake.taken_at), "h:mm a")}
                   </TableCell>

--- a/src/components/IntakeHistory.tsx
+++ b/src/components/IntakeHistory.tsx
@@ -24,7 +24,7 @@ interface EditIntakeFormProps {
   intake: {
     id: string;
     supplement_id: string;
-    quantity: number;
+    dosage: number;
     taken_at: string;
   };
   supplements: Array<{ id: string; name: string }>;
@@ -34,7 +34,7 @@ interface EditIntakeFormProps {
 const EditIntakeForm = ({ intake, supplements, onClose }: EditIntakeFormProps) => {
   const { toast } = useToast();
   const [supplementId, setSupplementId] = useState(intake.supplement_id);
-  const [quantity, setQuantity] = useState(intake.quantity);
+  const [dosage, setDosage] = useState(intake.dosage);
   const [time, setTime] = useState(format(new Date(intake.taken_at), "HH:mm"));
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -45,10 +45,10 @@ const EditIntakeForm = ({ intake, supplements, onClose }: EditIntakeFormProps) =
       takenAt.setHours(hours, minutes, 0, 0);
 
       const { error } = await supabase
-        .from('intake_logs')
+        .from('intakes')
         .update({
           supplement_id: supplementId,
-          quantity,
+          dosage,
           taken_at: takenAt.toISOString()
         })
         .eq('id', intake.id);
@@ -82,14 +82,14 @@ const EditIntakeForm = ({ intake, supplements, onClose }: EditIntakeFormProps) =
       </div>
       
       <div className="space-y-2">
-        <Label htmlFor="quantity">Quantity</Label>
-        <Input 
-          id="quantity" 
-          type="number" 
-          min="1" 
-          value={quantity}
-          onChange={(e) => setQuantity(Number(e.target.value))}
-          className="border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-black dark:text-white" 
+        <Label htmlFor="dosage">Dosage</Label>
+        <Input
+          id="dosage"
+          type="number"
+          min="1"
+          value={dosage}
+          onChange={(e) => setDosage(Number(e.target.value))}
+          className="border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 text-black dark:text-white"
         />
       </div>
       
@@ -118,7 +118,7 @@ const EditIntakeForm = ({ intake, supplements, onClose }: EditIntakeFormProps) =
 
 export function IntakeHistory() {
   const { user } = useUserProfile();
-  const { data: intakes, isLoading } = useTodayIntakes(user);
+  const { data: intakes, isLoading } = useTodayIntakes();
   const { data: supplements } = useSupplements(user);
   const { toast } = useToast();
   const queryClient = useQueryClient();
@@ -159,7 +159,7 @@ export function IntakeHistory() {
         <TableHeader>
           <TableRow>
             <TableHead>Supplement</TableHead>
-            <TableHead>Quantity</TableHead>
+            <TableHead>Dosage</TableHead>
             <TableHead>Time Taken</TableHead>
             <TableHead>Actions</TableHead>
           </TableRow>
@@ -170,7 +170,7 @@ export function IntakeHistory() {
             return (
               <TableRow key={intake.id}>
                 <TableCell>{supplement?.name}</TableCell>
-                <TableCell>{intake.quantity} units</TableCell>
+                <TableCell>{intake.dosage} units</TableCell>
                 <TableCell>{new Date(intake.taken_at).toLocaleTimeString()}</TableCell>
                 <TableCell>
                   <div className="flex gap-2">


### PR DESCRIPTION
## Summary
- fix `CalendarLog` and `IntakeHistory` to use the `intakes` table
- replace `quantity` references with `dosage`
- remove unused parameter in `useTodayIntakes`

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68432c9125d8832ab3f9a3cab0b4188c