### PR TITLE
Fix eslint empty interface warning

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
## Summary
- simplify Textarea props by using a type alias
- run eslint to verify the empty interface warning no longer appears for the textarea component

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843372c7f78832aa36537d285c59f71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal type definitions for textarea component properties without impacting functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->